### PR TITLE
feat: 重构 monorepo 包结构

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
           lfs: true
           submodules: recursive


### PR DESCRIPTION
本次改动主要包括：

1. 移除了导致无限循环的 postinstall 脚本
2. 修改了 lerna 配置，允许在 feature 分支上进行版本发布
3. 添加了 core 和 utils 包
4. 统一使用 @noteum 命名空间
5. 修复了工作流配置，确保正确检出 main 分支的最新代码

主要修改：
- 移除了 package.json 中的 postinstall 脚本，避免无限循环
- 修改了 lerna.json，允许在 feature 分支上进行版本发布
- 在 .github/workflows/version.yml 中添加了 ref: main 配置，确保工作流能获取到最新代码