### PR TITLE
fix: 在 CI 环境中自动确认版本更新

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Version and publish
         run: |
-          pnpm run version
+          pnpm run version --yes
           git push --follow-tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "lerna run build",
     "test": "lerna run test",
     "commit": "git-cz",
-    "version": "lerna version --conventionalCommits",
+    "version": "lerna version --conventionalCommits $*",
     "docker:build": "docker-compose build",
     "docker:dev": "docker-compose up -d && docker-compose exec dev bash",
     "docker:down": "docker-compose down"


### PR DESCRIPTION
本次改动主要包括：

1. 在 GitHub Actions 工作流中添加 --yes 参数，使 lerna version 命令自动确认版本更新
2. 修改 package.json 中的 version 脚本，使其能传递所有参数给 lerna version

这样在 CI 环境中运行 version 命令时就不会等待用户输入了。