### PR TITLE
chore: upgrade node.js to 22 and pnpm to 10.2.0

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8.15.9
+          version: 10.2.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     }
   },
   "engines": {
-    "node": ">=20.0.0",
-    "pnpm": ">=8.0.0"
+    "node": ">=22.0.0",
+    "pnpm": ">=10.0.0"
   },
   "scripts": {
 
@@ -34,5 +34,5 @@
       "path": "cz-conventional-changelog"
     }
   },
-  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
+  "packageManager": "pnpm@10.2.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "dev": "tsx watch src/app.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 更新内容

### 依赖升级
- Node.js 版本要求从 >=20.0.0 升级到 >=22.0.0
- pnpm 版本从 8.15.9 升级到 10.2.0

### 具体改动
1. 更新所有包的 engines 字段：
   - 根目录
   - @noteum/core
   - @noteum/server
   - @noteum/ui
   - @noteum/utils
   - @noteum/web

2. 更新 GitHub Actions 工作流配置：
   - 使用 Node.js 22
   - 使用 pnpm 10.2.0

### 升级原因
- Node.js 22 提供了更好的性能和新特性
- pnpm 10 提供了更好的依赖管理和更快的安装速度
- 保持项目使用最新的稳定版本