### PR TITLE
ci: 为 GitHub Actions 添加写入权限

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,6 +10,9 @@ jobs:
   version:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 更新内容

### 问题描述
在版本发布工作流程中，GitHub Actions 无法推送标签和更新，因为缺少必要的权限。

### 解决方案
为 GitHub Actions 工作流添加了以下权限：
- : 允许推送代码和标签
- : 允许更新 PR

### 技术细节
在  中添加了权限配置：


### 影响
- 版本发布工作流现在可以正常工作
- 自动化流程可以顺利完成版本更新和标签推送
- PR 可以被自动更新