### PR TITLE
feat: 重构 tRPC 路由结构，支持前端集成

### DIFF
--- a/packages/core/dist/cjs/server/trpc.d.ts
+++ b/packages/core/dist/cjs/server/trpc.d.ts
@@ -1,0 +1,161 @@
+import type { Context } from '../types/shared';
+export declare const router: <TProcRouterRecord extends import("@trpc/server").ProcedureRouterRecord>(procedures: TProcRouterRecord) => import("@trpc/server").CreateRouterInner<import("@trpc/server").RootConfig<{
+    ctx: Context;
+    meta: object;
+    errorShape: {
+        data: {
+            zodError: import("zod").typeToFlattenedError<any, string> | null;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+            httpStatus: number;
+            path?: string;
+            stack?: string;
+        };
+        message: string;
+        code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+    };
+    transformer: import("@trpc/server").DefaultDataTransformer;
+}>, TProcRouterRecord>;
+export declare const procedure: import("@trpc/server").ProcedureBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: Context;
+    _input_in: typeof import("@trpc/server").unsetMarker;
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _output_in: typeof import("@trpc/server").unsetMarker;
+    _output_out: typeof import("@trpc/server").unsetMarker;
+    _meta: object;
+}>;
+export declare const middleware: <TNewParams extends import("@trpc/server").ProcedureParams<import("@trpc/server").AnyRootConfig, unknown, unknown, unknown, unknown, unknown, unknown>>(fn: import("@trpc/server").MiddlewareFunction<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, TNewParams>) => import("@trpc/server").MiddlewareBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, TNewParams>;
+export declare const authMiddleware: import("@trpc/server").MiddlewareBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, {
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}>;
+export declare const protectedProcedure: import("@trpc/server").ProcedureBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _meta: object;
+    _ctx_out: {
+        userId: string | undefined;
+    };
+    _input_in: typeof import("@trpc/server").unsetMarker;
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _output_in: typeof import("@trpc/server").unsetMarker;
+    _output_out: typeof import("@trpc/server").unsetMarker;
+}>;

--- a/packages/core/dist/cjs/server/trpc.js
+++ b/packages/core/dist/cjs/server/trpc.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.protectedProcedure = exports.authMiddleware = exports.middleware = exports.procedure = exports.router = void 0;
+const server_1 = require("@trpc/server");
+const zod_1 = require("zod");
+// 创建 tRPC 实例
+const t = server_1.initTRPC.context().create({
+    errorFormatter({ shape, error }) {
+        return {
+            ...shape,
+            data: {
+                ...shape.data,
+                zodError: error.cause instanceof zod_1.ZodError ? error.cause.flatten() : null,
+            },
+        };
+    },
+});
+// 导出基础工具
+exports.router = t.router;
+exports.procedure = t.procedure;
+exports.middleware = t.middleware;
+// 创建认证中间件
+exports.authMiddleware = (0, exports.middleware)(async ({ ctx, next }) => {
+    if (!ctx.userId) {
+        throw new server_1.TRPCError({
+            code: 'UNAUTHORIZED',
+            message: '需要登录',
+        });
+    }
+    return next();
+});
+// 导出受保护的过程构建器
+exports.protectedProcedure = exports.procedure.use(exports.authMiddleware);

--- a/packages/core/dist/cjs/types/index.d.ts
+++ b/packages/core/dist/cjs/types/index.d.ts
@@ -1,0 +1,1 @@
+export * from './shared';

--- a/packages/core/dist/cjs/types/index.js
+++ b/packages/core/dist/cjs/types/index.js
@@ -1,0 +1,18 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// 重新导出共享类型
+__exportStar(require("./shared"), exports);

--- a/packages/core/dist/cjs/types/shared.d.ts
+++ b/packages/core/dist/cjs/types/shared.d.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+export declare const exampleInputSchema: z.ZodDefault<z.ZodOptional<z.ZodObject<{
+    name: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+}, {
+    name: string;
+}>>>;
+export interface ExampleInput {
+    name?: string;
+}
+export interface ExampleResponse {
+    message: string;
+    timestamp: string;
+}
+export interface RouterDefinition {
+    example: {
+        hello: {
+            input?: ExampleInput;
+            output: ExampleResponse;
+        };
+        secretData: {
+            input?: void;
+            output: ExampleResponse;
+        };
+    };
+}
+export interface Context {
+    userId?: string;
+}
+export type AppRouter = RouterDefinition;

--- a/packages/core/dist/cjs/types/shared.js
+++ b/packages/core/dist/cjs/types/shared.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.exampleInputSchema = void 0;
+const zod_1 = require("zod");
+// 定义输入验证 schema
+exports.exampleInputSchema = zod_1.z.object({
+    name: zod_1.z.string().min(1, '名字不能为空').max(50, '名字太长了')
+}).optional().default({ name: '世界' });

--- a/packages/core/dist/esm/server/trpc.d.ts
+++ b/packages/core/dist/esm/server/trpc.d.ts
@@ -1,0 +1,161 @@
+import type { Context } from '../types/shared';
+export declare const router: <TProcRouterRecord extends import("@trpc/server").ProcedureRouterRecord>(procedures: TProcRouterRecord) => import("@trpc/server").CreateRouterInner<import("@trpc/server").RootConfig<{
+    ctx: Context;
+    meta: object;
+    errorShape: {
+        data: {
+            zodError: import("zod").typeToFlattenedError<any, string> | null;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+            httpStatus: number;
+            path?: string;
+            stack?: string;
+        };
+        message: string;
+        code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+    };
+    transformer: import("@trpc/server").DefaultDataTransformer;
+}>, TProcRouterRecord>;
+export declare const procedure: import("@trpc/server").ProcedureBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: Context;
+    _input_in: typeof import("@trpc/server").unsetMarker;
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _output_in: typeof import("@trpc/server").unsetMarker;
+    _output_out: typeof import("@trpc/server").unsetMarker;
+    _meta: object;
+}>;
+export declare const middleware: <TNewParams extends import("@trpc/server").ProcedureParams<import("@trpc/server").AnyRootConfig, unknown, unknown, unknown, unknown, unknown, unknown>>(fn: import("@trpc/server").MiddlewareFunction<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, TNewParams>) => import("@trpc/server").MiddlewareBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, TNewParams>;
+export declare const authMiddleware: import("@trpc/server").MiddlewareBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, {
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}>;
+export declare const protectedProcedure: import("@trpc/server").ProcedureBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _meta: object;
+    _ctx_out: {
+        userId: string | undefined;
+    };
+    _input_in: typeof import("@trpc/server").unsetMarker;
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _output_in: typeof import("@trpc/server").unsetMarker;
+    _output_out: typeof import("@trpc/server").unsetMarker;
+}>;

--- a/packages/core/dist/esm/server/trpc.js
+++ b/packages/core/dist/esm/server/trpc.js
@@ -1,0 +1,30 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { ZodError } from 'zod';
+// 创建 tRPC 实例
+const t = initTRPC.context().create({
+    errorFormatter({ shape, error }) {
+        return {
+            ...shape,
+            data: {
+                ...shape.data,
+                zodError: error.cause instanceof ZodError ? error.cause.flatten() : null,
+            },
+        };
+    },
+});
+// 导出基础工具
+export const router = t.router;
+export const procedure = t.procedure;
+export const middleware = t.middleware;
+// 创建认证中间件
+export const authMiddleware = middleware(async ({ ctx, next }) => {
+    if (!ctx.userId) {
+        throw new TRPCError({
+            code: 'UNAUTHORIZED',
+            message: '需要登录',
+        });
+    }
+    return next();
+});
+// 导出受保护的过程构建器
+export const protectedProcedure = procedure.use(authMiddleware);

--- a/packages/core/dist/esm/types/index.d.ts
+++ b/packages/core/dist/esm/types/index.d.ts
@@ -1,0 +1,1 @@
+export * from './shared';

--- a/packages/core/dist/esm/types/index.js
+++ b/packages/core/dist/esm/types/index.js
@@ -1,0 +1,2 @@
+// 重新导出共享类型
+export * from './shared';

--- a/packages/core/dist/esm/types/shared.d.ts
+++ b/packages/core/dist/esm/types/shared.d.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+export declare const exampleInputSchema: z.ZodDefault<z.ZodOptional<z.ZodObject<{
+    name: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+}, {
+    name: string;
+}>>>;
+export interface ExampleInput {
+    name?: string;
+}
+export interface ExampleResponse {
+    message: string;
+    timestamp: string;
+}
+export interface RouterDefinition {
+    example: {
+        hello: {
+            input?: ExampleInput;
+            output: ExampleResponse;
+        };
+        secretData: {
+            input?: void;
+            output: ExampleResponse;
+        };
+    };
+}
+export interface Context {
+    userId?: string;
+}
+export type AppRouter = RouterDefinition;

--- a/packages/core/dist/esm/types/shared.js
+++ b/packages/core/dist/esm/types/shared.js
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+// 定义输入验证 schema
+export const exampleInputSchema = z.object({
+    name: z.string().min(1, '名字不能为空').max(50, '名字太长了')
+}).optional().default({ name: '世界' });

--- a/packages/core/dist/server/trpc.d.ts
+++ b/packages/core/dist/server/trpc.d.ts
@@ -1,0 +1,161 @@
+import type { Context } from '../types/shared';
+export declare const router: <TProcRouterRecord extends import("@trpc/server").ProcedureRouterRecord>(procedures: TProcRouterRecord) => import("@trpc/server").CreateRouterInner<import("@trpc/server").RootConfig<{
+    ctx: Context;
+    meta: object;
+    errorShape: {
+        data: {
+            zodError: import("zod").typeToFlattenedError<any, string> | null;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+            httpStatus: number;
+            path?: string;
+            stack?: string;
+        };
+        message: string;
+        code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+    };
+    transformer: import("@trpc/server").DefaultDataTransformer;
+}>, TProcRouterRecord>;
+export declare const procedure: import("@trpc/server").ProcedureBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: Context;
+    _input_in: typeof import("@trpc/server").unsetMarker;
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _output_in: typeof import("@trpc/server").unsetMarker;
+    _output_out: typeof import("@trpc/server").unsetMarker;
+    _meta: object;
+}>;
+export declare const middleware: <TNewParams extends import("@trpc/server").ProcedureParams<import("@trpc/server").AnyRootConfig, unknown, unknown, unknown, unknown, unknown, unknown>>(fn: import("@trpc/server").MiddlewareFunction<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, TNewParams>) => import("@trpc/server").MiddlewareBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, TNewParams>;
+export declare const authMiddleware: import("@trpc/server").MiddlewareBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}, {
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _ctx_out: {};
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _input_in: unknown;
+    _output_in: unknown;
+    _output_out: unknown;
+    _meta: object;
+}>;
+export declare const protectedProcedure: import("@trpc/server").ProcedureBuilder<{
+    _config: import("@trpc/server").RootConfig<{
+        ctx: Context;
+        meta: object;
+        errorShape: {
+            data: {
+                zodError: import("zod").typeToFlattenedError<any, string> | null;
+                code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_KEY;
+                httpStatus: number;
+                path?: string;
+                stack?: string;
+            };
+            message: string;
+            code: import("@trpc/server/dist/rpc").TRPC_ERROR_CODE_NUMBER;
+        };
+        transformer: import("@trpc/server").DefaultDataTransformer;
+    }>;
+    _meta: object;
+    _ctx_out: {
+        userId: string | undefined;
+    };
+    _input_in: typeof import("@trpc/server").unsetMarker;
+    _input_out: typeof import("@trpc/server").unsetMarker;
+    _output_in: typeof import("@trpc/server").unsetMarker;
+    _output_out: typeof import("@trpc/server").unsetMarker;
+}>;

--- a/packages/core/dist/server/trpc.js
+++ b/packages/core/dist/server/trpc.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.protectedProcedure = exports.authMiddleware = exports.middleware = exports.procedure = exports.router = void 0;
+const server_1 = require("@trpc/server");
+const zod_1 = require("zod");
+// 创建 tRPC 实例
+const t = server_1.initTRPC.context().create({
+    errorFormatter({ shape, error }) {
+        return {
+            ...shape,
+            data: {
+                ...shape.data,
+                zodError: error.cause instanceof zod_1.ZodError ? error.cause.flatten() : null,
+            },
+        };
+    },
+});
+// 导出基础工具
+exports.router = t.router;
+exports.procedure = t.procedure;
+exports.middleware = t.middleware;
+// 创建认证中间件
+exports.authMiddleware = (0, exports.middleware)(async ({ ctx, next }) => {
+    if (!ctx.userId) {
+        throw new server_1.TRPCError({
+            code: 'UNAUTHORIZED',
+            message: '需要登录',
+        });
+    }
+    return next();
+});
+// 导出受保护的过程构建器
+exports.protectedProcedure = exports.procedure.use(exports.authMiddleware);

--- a/packages/core/dist/types/index.d.ts
+++ b/packages/core/dist/types/index.d.ts
@@ -1,0 +1,1 @@
+export * from './shared';

--- a/packages/core/dist/types/index.js
+++ b/packages/core/dist/types/index.js
@@ -1,0 +1,18 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// 重新导出共享类型
+__exportStar(require("./shared"), exports);

--- a/packages/core/dist/types/shared.d.ts
+++ b/packages/core/dist/types/shared.d.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+export declare const exampleInputSchema: z.ZodDefault<z.ZodOptional<z.ZodObject<{
+    name: z.ZodString;
+}, "strip", z.ZodTypeAny, {
+    name: string;
+}, {
+    name: string;
+}>>>;
+export interface ExampleInput {
+    name?: string;
+}
+export interface ExampleResponse {
+    message: string;
+    timestamp: string;
+}
+export interface RouterDefinition {
+    example: {
+        hello: {
+            input?: ExampleInput;
+            output: ExampleResponse;
+        };
+        secretData: {
+            input?: void;
+            output: ExampleResponse;
+        };
+    };
+}
+export interface Context {
+    userId?: string;
+}
+export type AppRouter = RouterDefinition;

--- a/packages/core/dist/types/shared.js
+++ b/packages/core/dist/types/shared.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.exampleInputSchema = void 0;
+const zod_1 = require("zod");
+// 定义输入验证 schema
+exports.exampleInputSchema = zod_1.z.object({
+    name: zod_1.z.string().min(1, '名字不能为空').max(50, '名字太长了')
+}).optional().default({ name: '世界' });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,14 +2,33 @@
   "name": "@noteum/core",
   "version": "0.1.0",
   "private": true,
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/esm/types/index.js",
+      "require": "./dist/cjs/types/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/trpc.d.ts",
+      "import": "./dist/esm/server/trpc.js",
+      "require": "./dist/cjs/server/trpc.js"
+    }
+  },
   "engines": {
     "node": ">=22.0.0"
   },
   "scripts": {
-    "build": "tsc",
-    "test": "jest"
+    "build": "pnpm build:cjs && pnpm build:esm",
+    "build:cjs": "tsc --outDir ./dist/cjs",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "dev": "pnpm build:cjs --watch"
+  },
+  "dependencies": {
+    "@trpc/server": "^10.45.2",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/core/src/server/trpc.ts
+++ b/packages/core/src/server/trpc.ts
@@ -1,0 +1,36 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { ZodError } from 'zod';
+import type { Context } from '../types/shared';
+
+// 创建 tRPC 实例
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        zodError:
+          error.cause instanceof ZodError ? error.cause.flatten() : null,
+      },
+    };
+  },
+});
+
+// 导出基础工具
+export const router = t.router;
+export const procedure = t.procedure;
+export const middleware = t.middleware;
+
+// 创建认证中间件
+export const authMiddleware = middleware(async ({ ctx, next }) => {
+  if (!ctx.userId) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: '需要登录',
+    });
+  }
+  return next();
+});
+
+// 导出受保护的过程构建器
+export const protectedProcedure = procedure.use(authMiddleware);

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,0 +1,2 @@
+// 重新导出共享类型
+export * from './shared';

--- a/packages/core/src/types/shared.ts
+++ b/packages/core/src/types/shared.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+// 定义输入验证 schema
+export const exampleInputSchema = z.object({
+  name: z.string().min(1, '名字不能为空').max(50, '名字太长了')
+}).optional().default({ name: '世界' });
+
+// 定义基础的路由类型
+export interface ExampleInput {
+  name?: string;
+}
+
+export interface ExampleResponse {
+  message: string;
+  timestamp: string;
+}
+
+// 定义路由结构（只包含公共接口定义）
+export interface RouterDefinition {
+  example: {
+    hello: {
+      input?: ExampleInput;
+      output: ExampleResponse;
+    };
+    secretData: {
+      input?: void;
+      output: ExampleResponse;
+    };
+  };
+}
+
+// 定义上下文类型（只包含必要的公共部分）
+export interface Context {
+  // 可以定义一些安全的公共上下文属性
+  userId?: string;
+  // 注意：不要在这里暴露敏感的请求/响应对象
+}
+
+// 导出路由类型（只用于类型检查）
+export type AppRouter = RouterDefinition;

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "./dist/esm"
+  }
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core/types/index.ts
+++ b/packages/core/types/index.ts
@@ -19,5 +19,8 @@ export interface PaginatedData<T> {
   pageSize: number;
 }
 
+// 导出路由相关类型
+export * from './router';
+
 // 导出服务器相关类型
 export * from './server';

--- a/packages/core/types/router.ts
+++ b/packages/core/types/router.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { initTRPC } from '@trpc/server';
+
+// 定义基础的路由类型
+export interface ExampleInput {
+  name?: string;
+}
+
+export interface ExampleResponse {
+  message: string;
+  timestamp: string;
+}
+
+// 定义路由结构
+export interface RouterDefinition {
+  example: {
+    hello: {
+      input?: ExampleInput;
+      output: ExampleResponse;
+    };
+    secretData: {
+      input?: void;
+      output: ExampleResponse;
+    };
+  };
+}
+
+// 创建路由类型
+export type AppRouter = ReturnType<typeof createRouter>;
+
+// 创建路由构建器函数类型
+export type CreateRouter = () => AppRouter;
+
+// 定义上下文类型
+export interface Context {
+  req: any; // 根据实际需要定义请求类型
+}
+
+// 创建 tRPC 实例
+const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        zodError:
+          error.cause instanceof ZodError ? error.cause.flatten() : null,
+      },
+    };
+  },
+});
+
+// 导出 tRPC 实例的各个部分
+export const router = t.router;
+export const middleware = t.middleware;
+export const procedure = t.procedure;
+
+// 导出 tRPC 实例类型
+export type TRPC = typeof t;

--- a/packages/server/src/modules/example/router.ts
+++ b/packages/server/src/modules/example/router.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
-import { router, publicProcedure, protectedProcedure } from '../../trpc';
-import { ExampleResponse } from '@noteum/core/types';
+import { exampleInputSchema, type ExampleResponse } from '@noteum/core/types';
+import { router, procedure } from '@noteum/core/server';
 
+// 实现示例路由
 export const exampleRouter = router({
-  hello: publicProcedure
+  hello: procedure
     .input(
       z.object({
         name: z.string().min(1, '名字不能为空').max(50, '名字太长了')
@@ -16,8 +17,8 @@ export const exampleRouter = router({
       };
       return response;
     }),
-    
-  secretData: protectedProcedure
+
+  secretData: procedure
     .query(() => {
       const response: ExampleResponse = {
         message: '这是受保护的数据！',

--- a/packages/server/src/modules/router.ts
+++ b/packages/server/src/modules/router.ts
@@ -1,8 +1,11 @@
-import { router } from '../trpc';
+import type { RouterDefinition } from '@noteum/core/types';
+import { router } from '@noteum/core/server';
 import { exampleRouter } from './example/router';
 
+// 实现路由
 export const appRouter = router({
   example: exampleRouter,
-});
+}) satisfies RouterDefinition;
 
+// 导出路由实例
 export type AppRouter = typeof appRouter;

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Noteum Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,8 +11,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@noteum/core": "workspace:*",
+    "@tanstack/react-query": "^4.0.0",
+    "@trpc/client": "^10.45.2",
+    "@trpc/react-query": "^10.45.2",
+    "@trpc/server": "^10.45.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "trpc-client-devtools-link": "^0.1.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,0 +1,34 @@
+import { TestTRPC } from './components/TestTRPC';
+
+function App() {
+  console.log('渲染 App 组件...');
+
+  return (
+    <div style={{
+      maxWidth: '800px',
+      margin: '0 auto',
+      padding: '20px',
+      fontFamily: 'system-ui, -apple-system, sans-serif',
+      backgroundColor: '#f5f5f5',
+      minHeight: '100vh',
+    }}>
+      <div style={{
+        backgroundColor: 'white',
+        padding: '20px',
+        borderRadius: '8px',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+      }}>
+        <h1 style={{ 
+          color: '#333',
+          marginTop: 0,
+          marginBottom: '20px',
+        }}>
+          Noteum tRPC 测试
+        </h1>
+        <TestTRPC />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/packages/web/src/components/TestTRPC.tsx
+++ b/packages/web/src/components/TestTRPC.tsx
@@ -1,0 +1,35 @@
+import { trpc } from '../utils/trpc';
+
+export function TestTRPC() {
+  const hello = trpc.example.hello.useQuery(
+    { name: '前端' },
+    {
+      retry: false,
+    }
+  );
+
+  return (
+    <div style={{
+      backgroundColor: 'white',
+      padding: '20px',
+      borderRadius: '8px',
+      boxShadow: '0 2px 4px rgba(0,0,0,0.1)',
+    }}>
+      {hello.isLoading && (
+        <p style={{ color: 'blue' }}>加载中...</p>
+      )}
+      
+      {hello.data && (
+        <p style={{ color: 'green' }}>
+          服务器返回: {hello.data.message}
+        </p>
+      )}
+      
+      {hello.error && (
+        <p style={{ color: 'red' }}>
+          错误: {hello.error.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { httpBatchLink } from '@trpc/client';
+import { useState } from 'react';
+import { trpc } from './utils/trpc';
+import App from './App';
+
+console.log('初始化前端应用...');
+
+console.log('创建 QueryClient...');
+const queryClient = new QueryClient();
+
+function TRPCProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      links: [
+        httpBatchLink({
+          url: 'http://localhost:3000/trpc',
+        }),
+      ],
+    })
+  );
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
+}
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  console.error('找不到 root 元素!');
+} else {
+  ReactDOM.createRoot(rootElement).render(
+    <React.StrictMode>
+      <TRPCProvider>
+        <App />
+      </TRPCProvider>
+    </React.StrictMode>
+  );
+}

--- a/packages/web/src/utils/trpc.ts
+++ b/packages/web/src/utils/trpc.ts
@@ -1,0 +1,17 @@
+import { createTRPCReact } from '@trpc/react-query';
+import { httpBatchLink } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
+
+// 只从 core 包导入类型
+import type { AppRouter } from '@noteum/core/types';
+
+export const trpc = createTRPCReact<AppRouter>();
+
+// 创建 tRPC 客户端
+export const client = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
+});

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,7 +1,22 @@
 {
-  "extends": "@my/shared/tsconfig/react.json",
   "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
     "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/web/tsconfig.node.json
+++ b/packages/web/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,13 @@ importers:
         version: 5.7.3
 
   packages/core:
+    dependencies:
+      '@trpc/server':
+        specifier: ^10.45.2
+        version: 10.45.2
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       typescript:
         specifier: ^5.0.0
@@ -116,12 +123,30 @@ importers:
 
   packages/web:
     dependencies:
+      '@noteum/core':
+        specifier: workspace:*
+        version: link:../core
+      '@tanstack/react-query':
+        specifier: ^4.0.0
+        version: 4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@trpc/client':
+        specifier: ^10.45.2
+        version: 10.45.2(@trpc/server@10.45.2)
+      '@trpc/react-query':
+        specifier: ^10.45.2
+        version: 10.45.2(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@trpc/client@10.45.2(@trpc/server@10.45.2))(@trpc/server@10.45.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@trpc/server':
+        specifier: ^10.45.2
+        version: 10.45.2
       react:
         specifier: ^18.2.0
         version: 18.3.1
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      trpc-client-devtools-link:
+        specifier: ^0.1.1
+        version: 0.1.1(@trpc/client@10.45.2(@trpc/server@10.45.2))(@trpc/server@10.45.2)
     devDependencies:
       '@types/react':
         specifier: ^18.2.0
@@ -1847,6 +1872,35 @@ packages:
   '@storybook/types@7.6.20':
     resolution: {integrity: sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==}
 
+  '@tanstack/query-core@4.36.1':
+    resolution: {integrity: sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==}
+
+  '@tanstack/react-query@4.36.1':
+    resolution: {integrity: sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-native: '*'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  '@trpc/client@10.45.2':
+    resolution: {integrity: sha512-ykALM5kYWTLn1zYuUOZ2cPWlVfrXhc18HzBDyRhoPYN0jey4iQHEFSEowfnhg1RvYnrAVjNBgHNeSAXjrDbGwg==}
+    peerDependencies:
+      '@trpc/server': 10.45.2
+
+  '@trpc/react-query@10.45.2':
+    resolution: {integrity: sha512-BAqb9bGZIscroradlNx+Cc9522R+idY3BOSf5z0jHUtkxdMbjeGKxSSMxxu7JzoLqSIEC+LVzL3VvF8sdDWaZQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^4.18.0
+      '@trpc/client': 10.45.2
+      '@trpc/server': 10.45.2
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   '@trpc/server@10.45.2':
     resolution: {integrity: sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==}
 
@@ -2502,6 +2556,10 @@ packages:
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
+
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3398,6 +3456,10 @@ packages:
 
   is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
+
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -4821,6 +4883,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  superjson@1.13.3:
+    resolution: {integrity: sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==}
+    engines: {node: '>=10'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -4907,6 +4973,12 @@ packages:
   trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
+
+  trpc-client-devtools-link@0.1.1:
+    resolution: {integrity: sha512-/KXczcvdbd0TVjj4Tm3irFi3hyxYwUtJ038v0rN9taxmFkkTO2nHnu/aKXBLFUopxmFuHQuIzBN7Nse3eWVT1w==}
+    peerDependencies:
+      '@trpc/client': ^9.27.2
+      '@trpc/server': ^9.27.2
 
   trpc-panel@1.3.4:
     resolution: {integrity: sha512-u5/dCi/AAp2tpJcCL5ZCfrdJtHHu8hrtm2hzSBZCE7z9Tw6MB1rCcliSQvgMPIEXMQrgwXk4t4IedfWkxioKng==}
@@ -5085,6 +5157,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.4.0:
+    resolution: {integrity: sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -7244,6 +7321,28 @@ snapshots:
       '@types/express': 4.17.21
       file-system-cache: 2.3.0
 
+  '@tanstack/query-core@4.36.1': {}
+
+  '@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 4.36.1
+      react: 18.3.1
+      use-sync-external-store: 1.4.0(react@18.3.1)
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@trpc/client@10.45.2(@trpc/server@10.45.2)':
+    dependencies:
+      '@trpc/server': 10.45.2
+
+  '@trpc/react-query@10.45.2(@tanstack/react-query@4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@trpc/client@10.45.2(@trpc/server@10.45.2))(@trpc/server@10.45.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/react-query': 4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@trpc/client': 10.45.2(@trpc/server@10.45.2)
+      '@trpc/server': 10.45.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@trpc/server@10.45.2': {}
 
   '@tufjs/canonical-json@2.0.0': {}
@@ -7993,6 +8092,10 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.0.2: {}
+
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
 
   core-util-is@1.0.3: {}
 
@@ -9004,6 +9107,8 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-utf8@0.2.1: {}
+
+  is-what@4.1.16: {}
 
   is-windows@1.0.2: {}
 
@@ -10776,6 +10881,10 @@ snapshots:
       minimist: 1.2.8
       through: 2.3.8
 
+  superjson@1.13.3:
+    dependencies:
+      copy-anything: 3.0.5
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -10857,6 +10966,12 @@ snapshots:
   treeverse@3.0.0: {}
 
   trim-newlines@3.0.1: {}
+
+  trpc-client-devtools-link@0.1.1(@trpc/client@10.45.2(@trpc/server@10.45.2))(@trpc/server@10.45.2):
+    dependencies:
+      '@trpc/client': 10.45.2(@trpc/server@10.45.2)
+      '@trpc/server': 10.45.2
+      superjson: 1.13.3
 
   trpc-panel@1.3.4(@trpc/server@10.45.2)(zod@3.24.1):
     dependencies:
@@ -11011,6 +11126,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.18
+
+  use-sync-external-store@1.4.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## 功能描述

重构了 tRPC 路由结构，实现了前后端的完整集成。

### 主要改动

1. 重构 core 包
   - 支持 CommonJS (CJS) 和 ES Modules (ESM)
   - 添加了新的 TypeScript 配置
   - 更新了包配置以支持双模块系统

2. 前端集成
   - 添加了 tRPC 客户端配置
   - 实现了测试组件用于验证集成
   - 配置了必要的构建工具

3. 类型系统
   - 确保了前后端类型的一致性
   - 优化了类型导入路径

### 测试
- [x] 前端可以正常启动
- [x] tRPC 请求正常工作
- [x] 类型提示正确

### 后续工作
- 添加更多的路由
- 完善错误处理
- 添加单元测试