### PR TITLE
build(common): ignore tsbuildinfo files and clean them before versioning

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -62,6 +62,11 @@ jobs:
           pnpm build:server
           pnpm build:web
 
+      - name: Clean build artifacts
+        run: |
+          git clean -f "*.tsbuildinfo"
+          git checkout -- "*.tsbuildinfo"
+
       - name: Version and publish
         run: |
           pnpm run version --yes

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
+# Dependencies
 node_modules
 .pnpm-store
-doctor-storybook.log
+
+# Build outputs
 dist
 **/dist
+*.tsbuildinfo
+
+# Logs
+doctor-storybook.log
 /lerna-debug.log


### PR DESCRIPTION
## Description
This PR addresses the issue in the version workflow where uncommitted tsbuildinfo files were preventing version updates. It adds proper handling of TypeScript build info files and ensures they don't interfere with the versioning process.

## Changes
- Update .gitignore:
  - Add *.tsbuildinfo to ignored files
  - Reorganize file structure with categorized comments
- Update version.yml:
  - Add 'Clean build artifacts' step before versioning
  - Clean and reset tsbuildinfo files to prevent uncommitted changes

## Testing
- Verified that tsbuildinfo files are properly ignored
- Confirmed that version workflow can proceed without being blocked by build artifacts
- All CI checks pass (lint, type-check, test)

## Checklist
- [x] Build artifacts properly handled
- [x] CI/CD pipeline updated
- [x] Git ignore rules updated
- [x] All tests pass