### PR TITLE
fix(ci): resolve tsbuildinfo cleanup error in version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: Clean build artifacts
         run: |
-          git clean -f "*.tsbuildinfo"
-          git checkout -- "*.tsbuildinfo"
+          find . -name "*.tsbuildinfo" -delete
+          git checkout -- "*.tsbuildinfo" || true
 
       - name: Version and publish
         run: |


### PR DESCRIPTION
This PR fixes the tsbuildinfo cleanup error in the version workflow by using the  command to delete the files.