### PR TITLE
feat(web): 引入ReactFlow并创建工作流画布Demo

### DIFF
--- a/apps/web/app/routes/-components/flow/FlowDemo.client.tsx
+++ b/apps/web/app/routes/-components/flow/FlowDemo.client.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { type ReactNode } from 'react'
+import { ReactFlow, addEdge, useNodesState, useEdgesState } from '@xyflow/react'
+import type { Connection, Edge, Node } from '@xyflow/react'
+import '@xyflow/react/dist/style.css'
+
+const initialNodes: Node[] = [
+  {
+    id: '1',
+    type: 'input',
+    data: { label: '输入节点' },
+    position: { x: 250, y: 25 },
+  },
+  {
+    id: '2',
+    data: { label: '默认节点' },
+    position: { x: 100, y: 125 },
+  },
+  {
+    id: '3',
+    type: 'output',
+    data: { label: '输出节点' },
+    position: { x: 250, y: 250 },
+  },
+]
+
+const initialEdges: Edge[] = [
+  { id: 'e1-2', source: '1', target: '2' },
+  { id: 'e2-3', source: '2', target: '3' },
+]
+
+export function FlowDemoClient(): ReactNode {
+  const [nodes, _, onNodesChange] = useNodesState(initialNodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
+
+  // 处理新连接线的创建
+  const onConnect = (params: Connection) => {
+    setEdges((eds) => addEdge({ ...params, id: `e${params.source}-${params.target}` }, eds))
+  }
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return (
+    <div style={{ width: '100%', height: 'calc(100vh - 8rem)' }}>
+      <div className="bg-white/80 p-4 rounded-lg shadow absolute top-4 left-4 z-10">
+        <h3 className="text-lg font-semibold mb-2">流程图控制面板</h3>
+        <p className="text-sm text-gray-600 mb-2">可以拖拽节点和创建连接</p>
+        <ul className="text-sm text-gray-600">
+          <li>• 拖动节点改变位置</li>
+          <li>• 从节点连接点拖动创建新连接</li>
+          <li>• 使用鼠标滚轮缩放画布</li>
+        </ul>
+      </div>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        fitView
+        attributionPosition="bottom-right"
+      />
+    </div>
+  )
+}

--- a/apps/web/app/routes/flow.tsx
+++ b/apps/web/app/routes/flow.tsx
@@ -1,0 +1,16 @@
+import { type ReactNode } from 'react'
+import { FlowDemoClient } from './-components/flow/FlowDemo.client'
+import { createFileRoute } from '@tanstack/react-router'
+
+function FlowPage(): ReactNode {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">工作流程图演示</h1>
+      {typeof window !== 'undefined' && <FlowDemoClient />}
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/flow')({
+  component: FlowPage,
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@tanstack/router-plugin": "^1.112.17",
     "@trpc/client": "^10.45.2",
     "@trpc/server": "^10.45.2",
+    "@xyflow/react": "^12.4.4",
     "autoprefixer": "^10.4.20",
     "clsx": "^2.1.1",
     "lucide-react": "^0.482.0",


### PR DESCRIPTION
Resolves #57

## 描述
引入ReactFlow库并创建基础工作流程图演示页面。

## 变更内容
- 添加 @xyflow/react 依赖
- 创建流程图相关路由和组件
- 实现节点拖拽和连线功能
- 添加操作指引面板