### PR TITLE
Add Apache 2.0 license with Commons Clause

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,34 @@
+# License
+
+This software is licensed under the Apache License, Version 2.0 (the "License") WITH the Commons Clause;
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Commons Clause
+
+"Commons Clause" License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, "Sell" means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+## Additional Restrictions
+
+1. **Deployment Restriction**: You may deploy and use the Software for your own personal or internal business use. However, you may not deploy the Software as a service for others (multi-tenant service) without explicit written permission from the Licensor.
+
+2. **Modification and Distribution**: You may modify and distribute the Software in accordance with the Apache License 2.0, provided that any such distribution maintains these additional restrictions.
+
+3. **Attribution**: Any distribution or public use of the Software must maintain attribution to the original authors as specified in the Software.
+
+Software: Noteum
+Licensor: Jia Xia


### PR DESCRIPTION
This PR adds a LICENSE file to the project using Apache 2.0 with Commons Clause and additional deployment restrictions. The license allows personal and internal business use while prohibiting deployment as a multi-tenant service without explicit permission from the licensor.